### PR TITLE
start support for Travis Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
     - xmr
 
 before_install:
- - sudo add-apt-repository ppa:kzemek/boost
+ - sudo add-apt-repository ppa:kzemek/boost -y
  - sudo apt-get update
  - sudo apt-get install build-essential cmake pkg-config libssl-dev
  - sudo apt-get install boost1.58

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,6 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
-    # ubuntu trusty clang 3.5 (default for trusty)
-    - os: linux
-      dist: trusty
-      compiler: clang
-
     # ubuntu trusty clang 3.6
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ before_install:
 script:
   - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
-  - make
+  - make release
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
  - sudo add-apt-repository ppa:kzemek/boost -y
  - sudo apt-get update
  - sudo apt-get install build-essential cmake pkg-config libssl-dev
- - sudo apt-get install boost1.58
+ - sudo apt-get install boost1.58 libboost-filesystem1.58-dev libboost-chrono1.58-dev libboost-date-time1.58-dev libboost-serialization1.58-dev libboost-regex1.58-dev libboost-program-options1.58-dev libboost-system1.58-dev libboost-thread1.58-dev
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ branches:
 matrix:
   include:
 
-    # ubuntu trusty gcc 4.8
+    # ubuntu trusty gcc 4.8 (default for trusty)
     - os: linux
       dist: trusty
       compiler: gcc
-      env:
-         - MATRIX_EVAL="CC=gcc && CXX=g++"
 
     # ubuntu trusty gcc 4.9
     - os: linux
@@ -64,12 +62,10 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
-    # ubuntu trusty clang 3.5
+    # ubuntu trusty clang 3.5 (default for trusty)
     - os: linux
       dist: trusty
       compiler: clang
-      env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
 
     # ubuntu trusty clang 3.6
     - os: linux
@@ -158,4 +154,4 @@ before_install:
  - sudo apt-get update
  - sudo apt-get install boost1.58 libboost-filesystem1.58-dev libboost-chrono1.58-dev libboost-date-time1.58-dev libboost-serialization1.58-dev libboost-regex1.58-dev libboost-program-options1.58-dev libboost-system1.58-dev libboost-thread1.58-dev
 script:
-  - make release
+  - make -j2 release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+compiler: gcc
+
+branches:
+  only:
+    - xmr
+
+before_install:
+ - sudo apt-get install build-essential cmake pkg-config libboost-all-dev libssl-dev
+
+script:
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,12 @@
+dist: trusty
 language: cpp
 compiler: gcc
-sudo: required
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-5
-    - g++-5
 branches:
   only:
     - xmr
 before_install:
  - sudo add-apt-repository ppa:kzemek/boost -y
  - sudo apt-get update
- - sudo apt-get install build-essential cmake pkg-config libssl-dev
  - sudo apt-get install boost1.58 libboost-filesystem1.58-dev libboost-chrono1.58-dev libboost-date-time1.58-dev libboost-serialization1.58-dev libboost-regex1.58-dev libboost-program-options1.58-dev libboost-system1.58-dev libboost-thread1.58-dev
 script:
-  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
-  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
   - make release
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,156 @@ branches:
     - xmr
 matrix:
   include:
+
+    # ubuntu trusty gcc 4.8
     - os: linux
       dist: trusty
       compiler: gcc
+      env:
+         - MATRIX_EVAL="CC=gcc && CXX=g++"
+
+    # ubuntu trusty gcc 4.9
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
+    # ubuntu trusty gcc 5
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    # ubuntu trusty gcc 6
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    # ubuntu trusty gcc 7
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    # ubuntu trusty clang 3.5
     - os: linux
       dist: trusty
       compiler: clang
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+
+    # ubuntu trusty clang 3.6
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env:
+        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
+
+    # ubuntu trusty clang 3.7
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      env:
+        - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
+
+    # ubuntu trusty clang 3.8
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+          packages:
+            - clang-3.8
+      env:
+        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+
+    # ubuntu trusty clang 3.9
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-3.9
+          packages:
+            - clang-3.9
+      env:
+        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+
+    # ubuntu trusty clang 4.0
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+
+    # ubuntu trusty clang 5.0
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+
 before_install:
+ - eval "${MATRIX_EVAL}"
  - sudo add-apt-repository ppa:kzemek/boost -y
  - sudo apt-get update
  - sudo apt-get install boost1.58 libboost-filesystem1.58-dev libboost-chrono1.58-dev libboost-date-time1.58-dev libboost-serialization1.58-dev libboost-regex1.58-dev libboost-program-options1.58-dev libboost-system1.58-dev libboost-thread1.58-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ branches:
     - xmr
 
 before_install:
- - sudo apt-get install build-essential cmake pkg-config libboost-all-dev libssl-dev
+ - sudo add-apt-repository ppa:kzemek/boost
+ - sudo apt-get update
+ - sudo apt-get install build-essential cmake pkg-config libssl-dev
+ - sudo apt-get install boost1.58
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
-dist: trusty
 language: cpp
-compiler: gcc
 branches:
   only:
     - xmr
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      compiler: clang
 before_install:
  - sudo add-apt-repository ppa:kzemek/boost -y
  - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: cpp
 compiler: gcc
-
+sudo: required
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-5
+    - g++-5
 branches:
   only:
     - xmr
-
 before_install:
  - sudo add-apt-repository ppa:kzemek/boost -y
  - sudo apt-get update
  - sudo apt-get install build-essential cmake pkg-config libssl-dev
  - sudo apt-get install boost1.58 libboost-filesystem1.58-dev libboost-chrono1.58-dev libboost-date-time1.58-dev libboost-serialization1.58-dev libboost-regex1.58-dev libboost-program-options1.58-dev libboost-system1.58-dev libboost-thread1.58-dev
-
 script:
+  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
+  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
   - make
+  


### PR DESCRIPTION
Test matrix currently includes:
 - GCC: 4.8, 4.9, 5, 6, 7
 - Clang: 3.6, 3.7, 3.8, 3.9, 4, 5
 - On: Ubuntu Trusty 64bit
 - With: Boost 1.58 and using all possible vendored libs
 - Target: make release

Apologies that it's spread over 11 commits. Remote CI is a bit trial and error. I can rebase and make a clean single-commit if preferred.