### PR TITLE
complete work around new difficulty algorithm

### DIFF
--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -45,7 +45,7 @@ namespace
     for (size_t i = 0; i < new_block_count; ++i)
     {
       block blk_next;
-      difficulty_type diffic = next_difficulty(timestamps, cummulative_difficulties,DIFFICULTY_TARGET_V1);
+      difficulty_type diffic = next_difficulty(DIFFICULTY_TARGET_V1, timestamps, cummulative_difficulties);
       if (!generator.construct_block_manually(blk_next, blk_prev, miner_account,
         test_generator::bf_timestamp | test_generator::bf_diffic, 0, 0, blk_prev.timestamp, crypto::hash(), diffic))
         return false;
@@ -175,7 +175,7 @@ bool gen_block_invalid_nonce::generate(std::vector<test_event_entry>& events) co
     return false;
 
   // Create invalid nonce
-  difficulty_type diffic = next_difficulty(timestamps, commulative_difficulties,DIFFICULTY_TARGET_V1);
+  difficulty_type diffic = next_difficulty(DIFFICULTY_TARGET_V1, timestamps, commulative_difficulties);
   assert(1 < diffic);
   const block& blk_last = boost::get<block>(events.back());
   uint64_t timestamp = blk_last.timestamp;
@@ -572,7 +572,7 @@ bool gen_block_invalid_binary_format::generate(std::vector<test_event_entry>& ev
   do
   {
     blk_last = boost::get<block>(events.back());
-    diffic = next_difficulty(timestamps, cummulative_difficulties,DIFFICULTY_TARGET_V1);
+    diffic = next_difficulty(DIFFICULTY_TARGET_V1, timestamps, cummulative_difficulties);
     if (!lift_up_difficulty(events, timestamps, cummulative_difficulties, generator, 1, blk_last, miner_account))
       return false;
     std::cout << "Block #" << events.size() << ", difficulty: " << diffic << std::endl;
@@ -587,7 +587,7 @@ bool gen_block_invalid_binary_format::generate(std::vector<test_event_entry>& ev
   std::vector<crypto::hash> tx_hashes;
   tx_hashes.push_back(get_transaction_hash(tx_0));
   size_t txs_size = get_object_blobsize(tx_0);
-  diffic = next_difficulty(timestamps, cummulative_difficulties,DIFFICULTY_TARGET_V1);
+  diffic = next_difficulty(DIFFICULTY_TARGET_V1, timestamps, cummulative_difficulties);
   if (!generator.construct_block_manually(blk_test, blk_last, miner_account,
     test_generator::bf_diffic | test_generator::bf_timestamp | test_generator::bf_tx_hashes, 0, 0, blk_last.timestamp,
     crypto::hash(), diffic, transaction(), tx_hashes, txs_size))

--- a/tests/difficulty/difficulty.cpp
+++ b/tests/difficulty/difficulty.cpp
@@ -63,8 +63,9 @@ int main(int argc, char *argv[]) {
             begin = end - DIFFICULTY_WINDOW;
         }
         uint64_t res = cryptonote::next_difficulty(
+            DEFAULT_TEST_DIFFICULTY_TARGET,
             vector<uint64_t>(timestamps.begin() + begin, timestamps.begin() + end),
-            vector<uint64_t>(cumulative_difficulties.begin() + begin, cumulative_difficulties.begin() + end), DEFAULT_TEST_DIFFICULTY_TARGET);
+            vector<uint64_t>(cumulative_difficulties.begin() + begin, cumulative_difficulties.begin() + end));
         if (res != difficulty) {
             cerr << "Wrong difficulty for block " << n << endl
                 << "Expected: " << difficulty << endl


### PR DESCRIPTION
- next_difficulty() signature fixed to match difficulty algorithm changes
- all tests compile now
- team feedback needed on failing tests

````
Running tests...
Test project /Users/michael/Documents/ITNS/GitHub/intensecoin/build/release
      Start  1: hash-target
 1/13 Test  #1: hash-target ......................   Passed    0.07 sec
      Start  2: coretests
 2/13 Test  #2: coretests ........................***Exception: SegFault  0.07 sec
      Start  3: cncrypto
 3/13 Test  #3: cncrypto .........................   Passed    9.11 sec
      Start  4: unit_tests
 4/13 Test  #4: unit_tests .......................***Failed    9.51 sec
      Start  5: difficulty
 5/13 Test  #5: difficulty .......................***Failed    0.01 sec
      Start  6: hash-fast
 6/13 Test  #6: hash-fast ........................   Passed    0.01 sec
      Start  7: hash-slow
 7/13 Test  #7: hash-slow ........................   Passed    0.12 sec
      Start  8: hash-tree
 8/13 Test  #8: hash-tree ........................   Passed    0.01 sec
      Start  9: hash-extra-blake
 9/13 Test  #9: hash-extra-blake .................   Passed    0.01 sec
      Start 10: hash-extra-groestl
10/13 Test #10: hash-extra-groestl ...............   Passed    0.01 sec
      Start 11: hash-extra-jh
11/13 Test #11: hash-extra-jh ....................   Passed    0.02 sec
      Start 12: hash-extra-skein
12/13 Test #12: hash-extra-skein .................   Passed    0.01 sec
      Start 13: libwallet_api_tests

13/13 Test #13: libwallet_api_tests ..............***Failed  242.65 sec

69% tests passed, 4 tests failed out of 13

Total Test time (real) = 261.64 sec

The following tests FAILED:
	  2 - coretests (SEGFAULT)
	  4 - unit_tests (Failed)
	  5 - difficulty (Failed)
	 13 - libwallet_api_tests (Failed)
Errors while running CTest
````