### PR TITLE
Fix missing prototype of inet_ntop/inet_pton.

### DIFF
--- a/external/unbound/config.h.cmake.in
+++ b/external/unbound/config.h.cmake.in
@@ -1101,6 +1101,14 @@ char *strsep(char **stringp, const char *delim);
 int isblank(int c);
 #endif
 
+#if defined(HAVE_INET_NTOP) && !HAVE_DECL_INET_NTOP
+const char *inet_ntop(int af, const void *__restrict src, char *__restrict dst, socklen_t size);
+#endif
+
+#if defined(HAVE_INET_PTON) && !HAVE_DECL_INET_PTON
+int inet_pton(int af, const char* src, void* dst);
+#endif
+
 #if !defined(HAVE_STRPTIME) || !defined(STRPTIME_WORKS)
 #define strptime unbound_strptime
 struct tm;


### PR DESCRIPTION
For example mingw-w64 headers are missing prototypes of inet_ntop and inet_pton.
Use same logic as in config.h.in to add missing prototypes.