### PR TITLE
Issue 59

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,4 +192,4 @@ before_install:
  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libboost-thread1.58-dev          ; fi
 
 script:
-  - make -j2 release
+  - make -j2 release-test

--- a/src/cryptonote_basic/CMakeLists.txt
+++ b/src/cryptonote_basic/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(cryptonote_basic
   PUBLIC
     common
     cncrypto
+    cryptonote_core
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY}

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -783,33 +783,6 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
-  bool generate_genesis_block(block& bl)
-  {
-    //genesis block
-    bl = boost::value_initialized<block>();
-
-
-    account_public_address ac = boost::value_initialized<account_public_address>();
-    std::vector<size_t> sz;
-    cryptonote::construct_miner_tx(0, 0, 0, 0, 0, ac, bl.miner_tx); // zero fee in genesis
-    blobdata txb = tx_to_blob(bl.miner_tx);
-    std::string hex_tx_represent = string_tools::buff_to_hex_nodelimer(txb);
-
-    //hard code coinbase tx in genesis block, because "tru" generating tx use random, but genesis should be always the same
-    std::string genesis_coinbase_tx_hex = config::GENESIS_TX;
-
-    blobdata tx_bl;
-    string_tools::parse_hexstr_to_binbuff(genesis_coinbase_tx_hex, tx_bl);
-    bool r = parse_and_validate_tx_from_blob(tx_bl, bl.miner_tx);
-    CHECK_AND_ASSERT_MES(r, false, "failed to parse coinbase tx from hard coded blob");
-    bl.major_version = CURRENT_BLOCK_MAJOR_VERSION;
-    bl.minor_version = CURRENT_BLOCK_MINOR_VERSION;
-    bl.timestamp = 0;
-    bl.nonce = config::GENESIS_NONCE;
-    miner::find_nonce_for_given_block(bl, 1, 0);
-    return true;
-  }
-  //---------------------------------------------------------------
   bool get_genesis_block_hash(crypto::hash& h)
   {
 	  static std::atomic<bool> cached(false);
@@ -821,7 +794,7 @@ namespace cryptonote
 		  if (!cached)
 		  {
 			  block genesis_block;
-			  if (!generate_genesis_block(genesis_block))
+			  if (!generate_genesis_block(genesis_block, config::GENESIS_TX, config::GENESIS_NONCE))
 				  return false;
 
 			  if (!get_block_hash(genesis_block, genesis_block_hash))


### PR DESCRIPTION
_Changes to address issue https://github.com/valiant1x/intensecoin/issues/59_

The locally defined generate_genesis_block in the cryptonote_basic lib still depends on methods in the cryptonote_core lib. This leads to an issue when linking the fuzz tests.

I've added a new dependence so cryptonote_basic links against cryptonote_core.

This could be removed in the future if we find a way to avoid calling generate_genesis_block in cryptonote_format_utils.cpp:check_proof_of_work_v2 or move that functionality to cryptonote_core directly.