### PR TITLE
update checkpoints v4 hardfork

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4215,7 +4215,7 @@ void Blockchain::cancel()
 }
 
 #if defined(PER_BLOCK_CHECKPOINT)
-static const char expected_block_hashes_hash[] = "752b45baf2529f7e27e9ec14c32a755a54e8a7f093f1d6cfe239b07497481119";
+static const char expected_block_hashes_hash[] = "b5405a9f552d35e52e6036595a4c9788c63f42c70b387e577ed9ed16fcc871ea";
 void Blockchain::load_compiled_in_block_hashes()
 {
   if (m_fast_sync && get_blocks_dat_start(m_testnet) != nullptr && get_blocks_dat_size(m_testnet) > 0)


### PR DESCRIPTION
without checkpoints after the v4 fork (block 166134 or later), the chain was failing to cross the 167000 threshold. the v3 chain went up to 173000 or so and was getting re-adopted at 167000. with proper checkpoints, it should not have issues with reorganization.