### PR TITLE
Fix block template failure with large TX pool

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -293,7 +293,6 @@ namespace cryptonote
       }
       else
       {
-		  MWARNING("Processing RCT tx ..");
         ar.tag("rct_signatures");
         if (!vin.empty())
         {

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -88,7 +88,7 @@ namespace cryptonote {
   //-----------------------------------------------------------------------------------------------
   bool get_block_reward(size_t median_size, size_t current_block_size, uint64_t already_generated_coins, uint64_t &reward, uint8_t version) {
     static_assert(DIFFICULTY_TARGET_V2%60==0&&DIFFICULTY_TARGET_V1%60==0,"difficulty targets must be a multiple of 60");
-    const int target = version < 2 ? DIFFICULTY_TARGET_V1 : DIFFICULTY_TARGET_V2;
+    const int target = version < BLOCK_MAJOR_VERSION_2 ? DIFFICULTY_TARGET_V1 : DIFFICULTY_TARGET_V2;
     const int target_minutes = target / 60;
     const int emission_speed_factor = EMISSION_SPEED_FACTOR_PER_MINUTE - (target_minutes-1);
 	const uint64_t orig_already_generated_coins = already_generated_coins;

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -69,9 +69,9 @@ namespace cryptonote {
   //-----------------------------------------------------------------------------------------------
   size_t get_min_block_size(uint8_t version)
   {
-    if (version < 2)
+    if (version < BLOCK_MAJOR_VERSION_2)
       return CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1;
-    if (version < 5)
+    if (version < BLOCK_MAJOR_VERSION_5)
       return CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2;
     return CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5;
   }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -48,6 +48,7 @@
 #define BLOCK_MAJOR_VERSION_2                           2
 #define BLOCK_MAJOR_VERSION_3                           3
 #define BLOCK_MAJOR_VERSION_4							4
+#define BLOCK_MAJOR_VERSION_5							5
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT              500
 #define CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE             0
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -71,7 +71,6 @@
 #define FEE_PER_KB                                      ((uint64_t)100000)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE                     ((uint64_t)200000) // 2 * pow(10,5)
 #define DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD            ((uint64_t)100000000000) // 10 * pow(10,10)
-#define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)2000000000 * (uint64_t)CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2 / CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5)
 
 #define ORPHANED_BLOCKS_MAX_COUNT                       100
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1112,7 +1112,11 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
   diffic = get_difficulty_for_next_block();
   CHECK_AND_ASSERT_MES(diffic, false, "difficulty overhead.");
 
-  median_size = m_current_block_cumul_sz_limit / 2;
+  //quick fix - to calculate reward without a penalty, use the full reward zone as the median
+  //ITNS's large blocks every 5 was making the cumulative_size_limit larger than this but not
+  //accounting for the decreased reward correctly
+  //median_size = m_current_block_cumul_sz_limit / 2;
+  median_size = get_min_block_size(b.major_version);
   already_generated_coins = m_db->get_block_already_generated_coins(height - 1);
 
   CRITICAL_REGION_END();

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1112,11 +1112,18 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
   diffic = get_difficulty_for_next_block();
   CHECK_AND_ASSERT_MES(diffic, false, "difficulty overhead.");
 
-  //quick fix - to calculate reward without a penalty, use the full reward zone as the median
-  //ITNS's large blocks every 5 was making the cumulative_size_limit larger than this but not
-  //accounting for the decreased reward correctly
-  //median_size = m_current_block_cumul_sz_limit / 2;
-  median_size = get_min_block_size(b.major_version);
+  //to calculate reward without a penalty, use the full reward zone as the median, or the median size of the last 100 blocks
+  //previously median_size was cumulative limit / 2. ITNS's large blocks every 5 was making the cumulative_size_limit larger 
+  //than this but not accounting for the decreased reward correctly
+  std::vector<size_t> last_blocks_sizes;
+  get_last_n_blocks_sizes(last_blocks_sizes, CRYPTONOTE_REWARD_BLOCKS_WINDOW);
+  size_t median_last_blocks = epee::misc_utils::median(last_blocks_sizes);
+  median_size = std::max(median_last_blocks, get_min_block_size(b.major_version));
+  //the reason this is so lengthy is to accommodate for what happens in the future in validate_miner_transaction
+  //using the named constant as a reminder to change this section when we go to v5 and allow a max of (m_current_block_cumul_sz_limit / 2) for all blocks
+  if (b.major_version < BLOCK_MAJOR_VERSION_5)
+	median_size = (median_size > (m_current_block_cumul_sz_limit / 2) ? (m_current_block_cumul_sz_limit / 2) : median_size);
+  
   already_generated_coins = m_db->get_block_already_generated_coins(height - 1);
 
   CRITICAL_REGION_END();

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3499,7 +3499,8 @@ leave:
 //------------------------------------------------------------------
 bool Blockchain::update_next_cumulative_size_limit()
 {
-	if (get_current_hard_fork_version() >= BLOCK_MAJOR_VERSION_3)
+	if (get_current_hard_fork_version() == BLOCK_MAJOR_VERSION_3 || 
+		get_current_hard_fork_version() == BLOCK_MAJOR_VERSION_4)
 	{
 		//support ITNS max cumulative size limit change since 65k: large blocks every 5 blocks only
 		//transaction size is also checked here.
@@ -3508,6 +3509,7 @@ bool Blockchain::update_next_cumulative_size_limit()
 		size_limit += ((height * (height % 5 == 0 ? (35 * 100 * 1024) : (100 * 1024)))
 			/ (365 * 24 * 60 * 60 / DIFFICULTY_TARGET_V2));
 		m_current_block_cumul_sz_limit = size_limit;
+		//this value is inherently capped at (full_reward_zone * 2) because get_block_reward limits the size to full_reward_zone * 2
 		MDEBUG("Setting m_current_block_cumul_sz_limit to " << size_limit << " - height: " << height << " TH " << m_db->top_block_hash());
 	}
 	else

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -877,8 +877,8 @@ namespace cryptonote
         continue;
       }
 
-      // start using the optimal filling algorithm from v5
-      if (version >= 5)
+      // start using the optimal filling algorithm from v4
+      if (version >= BLOCK_MAJOR_VERSION_4)
       {
         // If we're getting lower coinbase tx,
         // stop including more tx


### PR DESCRIPTION
The block template was being incorrectly filled when the transaction mempool contained a large number of transactions, causing blocks to fail verification when submitted to the daemon.