### PR TITLE
Fix finding readline on MSYS2 + MinGW-w64.

### DIFF
--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -21,7 +21,6 @@
 find_path(Readline_ROOT_DIR
     NAMES include/readline/readline.h
     PATHS /usr/local/opt/readline/ /opt/local/ /usr/local/ /usr/
-    NO_DEFAULT_PATH
 )
 
 find_path(Readline_INCLUDE_DIR
@@ -64,7 +63,7 @@ check_function_exists(rl_filename_completion_function HAVE_COMPLETION_FUNCTION)
 
 if(NOT HAVE_COMPLETION_FUNCTION)
   unset(READLINE_FOUND)
-  set(CMAKE_REQUIRED_LIBRARIES ${Termcap_LIBRARY})
+  set(CMAKE_REQUIRED_LIBRARIES ${Readline_LIBRARY} ${Termcap_LIBRARY})
   check_function_exists(rl_copy_text HAVE_COPY_TEXT_TC)
   check_function_exists(rl_filename_completion_function HAVE_COMPLETION_FUNCTION_TC)
   set(HAVE_COMPLETION_FUNCTION ${HAVE_COMPLETION_FUNCTION_TC})

--- a/contrib/epee/src/readline_buffer.cpp
+++ b/contrib/epee/src/readline_buffer.cpp
@@ -1,7 +1,9 @@
 #include "readline_buffer.h"
 #include <readline/readline.h>
 #include <readline/history.h>
+#if !defined(__MINGW32__) && !defined(__MINGW64__)
 #include <sys/select.h>
+#endif
 #include <unistd.h>
 #include <boost/thread.hpp>
 #include <boost/algorithm/string.hpp>


### PR DESCRIPTION
MinGW-w64 has readline in /mingw64/include and /mingw64/lib
* we can't use NO_DEFAULT_PATH when searching for Readline_ROOT_DIR as MSYS2 has multiple copies of readline and hardcoding all choices might cause wrong version to be used
* as readline is static library on all RedHat Linux based systems (including Cygwin and MinGW), we need to explicitly link to termcap or we get missing symbols when testing

```
C:\build\git\intensecoin\build>find "Readline" CMakeCache.txt

---------- CMAKECACHE.TXT
Readline_INCLUDE_DIR:PATH=C:/msys64/mingw64/include
Readline_LIBRARY:FILEPATH=C:/msys64/mingw64/lib/libreadline.a
Readline_ROOT_DIR:PATH=C:/msys64/mingw64
//ADVANCED property for variable: Readline_INCLUDE_DIR
Readline_INCLUDE_DIR-ADVANCED:INTERNAL=1
//ADVANCED property for variable: Readline_LIBRARY
Readline_LIBRARY-ADVANCED:INTERNAL=1
//ADVANCED property for variable: Readline_ROOT_DIR
Readline_ROOT_DIR-ADVANCED:INTERNAL=1
```